### PR TITLE
Fixed branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [<img src="./ecs-icon.png" align="right" width="20%">](https://aws.amazon.com/ecs/)
 # Awesome ECS
 
-A curated list of guides, development tools, and resources for [AWS EC2 Container Service](https://aws.amazon.com/ecs/) (ECS). This list includes both community created content as well as content created by AWS.
+A curated list of guides, development tools, and resources for [Amazon EC2 Container Service](https://aws.amazon.com/ecs/) (ECS). This list includes both community created content as well as content created by AWS.
 
 _Want to add something? Open a PR!_ 🙂
 


### PR DESCRIPTION
Fixed “AWS EC2 Container Service” to “Amazon EC2 Container Service” 